### PR TITLE
Add page titles for all docs

### DIFF
--- a/apps/website/src/pages/404.tsx
+++ b/apps/website/src/pages/404.tsx
@@ -1,22 +1,29 @@
 import { Center } from '@edge-ui/react';
+import Head from 'next/head';
 import Link from 'next/link';
 
 export default function Custom404() {
     return (
-        <Center>
-            <div className="text-center">
-                <h1 className="font-black text-gray-200 text-9xl dark:text-gray-700">404</h1>
+        <>
+            <Head>
+                <title>404 Not Found</title>
+            </Head>
 
-                <p className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-4xl">Uh-oh!</p>
+            <Center>
+                <div className="text-center">
+                    <h1 className="font-black text-gray-200 text-9xl dark:text-gray-700">404</h1>
 
-                <p className="mt-4 text-gray-500 dark:text-gray-400">We can{"'"}t find that page.</p>
-                <Link
-                    href="/"
-                    className="inline-block px-5 py-3 mt-6 text-sm font-medium text-primary-foreground bg-primary text-pri rounded-sm"
-                >
-                    Go Back Home
-                </Link>
-            </div>
-        </Center>
+                    <p className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-4xl">Uh-oh!</p>
+
+                    <p className="mt-4 text-gray-500 dark:text-gray-400">We can{"'"}t find that page.</p>
+                    <Link
+                        href="/"
+                        className="inline-block px-5 py-3 mt-6 text-sm font-medium text-primary-foreground bg-primary text-pri rounded-sm"
+                    >
+                        Go Back Home
+                    </Link>
+                </div>
+            </Center>
+        </>
     );
 }

--- a/apps/website/src/pages/_app.tsx
+++ b/apps/website/src/pages/_app.tsx
@@ -5,7 +5,6 @@ import { Manrope } from 'next/font/google';
 import {
     EdgeUIProvider,
     Heading,
-    Layout,
     Paragraph,
     Toaster,
     Blockquote,

--- a/apps/website/src/pages/docs/components/accordion.mdx
+++ b/apps/website/src/pages/docs/components/accordion.mdx
@@ -1,4 +1,9 @@
 import { AccordionExample } from '@/components/docs/accordion';
+import Head from 'next/head';
+
+<Head>
+  <title>Accordion | EdgeUI</title>
+</Head>
 
 # Accordion
 

--- a/apps/website/src/pages/docs/components/alert-dialog.mdx
+++ b/apps/website/src/pages/docs/components/alert-dialog.mdx
@@ -1,4 +1,9 @@
 import { AlertDialogExample } from '@/components/docs/alert';
+import Head from 'next/head';
+
+<Head>
+  <title>Alert Dialog | EdgeUI</title>
+</Head>
 
 # Alert Dialog
 

--- a/apps/website/src/pages/docs/components/alert.mdx
+++ b/apps/website/src/pages/docs/components/alert.mdx
@@ -1,4 +1,9 @@
 import { AlertExample } from '@/components/docs/alert';
+import Head from 'next/head';
+
+<Head>
+  <title>Alert | EdgeUI</title>
+</Head>
 
 # Alert
 

--- a/apps/website/src/pages/docs/components/avatar.mdx
+++ b/apps/website/src/pages/docs/components/avatar.mdx
@@ -1,4 +1,9 @@
 import { AvatarExample } from '@/components/docs/avatar';
+import Head from 'next/head';
+
+<Head>
+  <title>Avatar | EdgeUI</title>
+</Head>
 
 # Avatar
 

--- a/apps/website/src/pages/docs/components/badge.mdx
+++ b/apps/website/src/pages/docs/components/badge.mdx
@@ -1,4 +1,9 @@
 import { Badges } from '@/components/docs/badges';
+import Head from 'next/head';
+
+<Head>
+  <title>Badge | EdgeUI</title>
+</Head>
 
 # Badge
 

--- a/apps/website/src/pages/docs/components/button.mdx
+++ b/apps/website/src/pages/docs/components/button.mdx
@@ -1,4 +1,9 @@
 import { Buttons } from '@/components/docs/buttons';
+import Head from 'next/head';
+
+<Head>
+  <title>Button | EdgeUI</title>
+</Head>
 
 # Button
 

--- a/apps/website/src/pages/docs/components/calendar.mdx
+++ b/apps/website/src/pages/docs/components/calendar.mdx
@@ -1,4 +1,9 @@
 import { CalendarExample } from '@/components/docs/calendar';
+import Head from 'next/head';
+
+<Head>
+  <title>Calendar | EdgeUI</title>
+</Head>
 
 # Calendar
 

--- a/apps/website/src/pages/docs/components/card.mdx
+++ b/apps/website/src/pages/docs/components/card.mdx
@@ -1,4 +1,9 @@
 import { CardExample } from '@/components/docs/card';
+import Head from 'next/head';
+
+<Head>
+  <title>Card | EdgeUI</title>
+</Head>
 
 # Card
 

--- a/apps/website/src/pages/docs/components/checkbox.mdx
+++ b/apps/website/src/pages/docs/components/checkbox.mdx
@@ -1,4 +1,9 @@
 import { CheckboxExample } from '@/components/docs/inputs'
+import Head from 'next/head';
+
+<Head>
+  <title>Checkbox | EdgeUI</title>
+</Head>
 
 # Checkbox
 

--- a/apps/website/src/pages/docs/components/code.mdx
+++ b/apps/website/src/pages/docs/components/code.mdx
@@ -1,4 +1,9 @@
 import { CodeBlockExample } from '@/components/docs/code';
+import Head from 'next/head';
+
+<Head>
+  <title>Code | EdgeUI</title>
+</Head>
 
 # Code
 

--- a/apps/website/src/pages/docs/components/command-dialog.mdx
+++ b/apps/website/src/pages/docs/components/command-dialog.mdx
@@ -1,4 +1,9 @@
 import { CommandDialogExample } from '@/components/docs/commandDialog'
+import Head from 'next/head';
+
+<Head>
+  <title>Command Dialog | EdgeUI</title>
+</Head>
 
 # Command Dialog
 

--- a/apps/website/src/pages/docs/components/context-menu.mdx
+++ b/apps/website/src/pages/docs/components/context-menu.mdx
@@ -1,4 +1,9 @@
 import { ContextMenuExample } from '@/components/docs/contextMenu';
+import Head from 'next/head';
+
+<Head>
+  <title>Context Menu | EdgeUI</title>
+</Head>
 
 # Context Menu
 

--- a/apps/website/src/pages/docs/components/dialog.mdx
+++ b/apps/website/src/pages/docs/components/dialog.mdx
@@ -1,4 +1,9 @@
 import { DialogExample } from '@/components/docs/dialog';
+import Head from 'next/head';
+
+<Head>
+  <title>Dialog | EdgeUI</title>
+</Head>
 
 # Dialog
 

--- a/apps/website/src/pages/docs/components/dropdown-menu.mdx
+++ b/apps/website/src/pages/docs/components/dropdown-menu.mdx
@@ -1,4 +1,9 @@
 import { DropdownMenuExample } from '@/components/docs/dropdownMenu';
+import Head from 'next/head';
+
+<Head>
+  <title>Dropdown Menu | EdgeUI</title>
+</Head>
 
 # Dropdown Menu
 

--- a/apps/website/src/pages/docs/components/hover-card.mdx
+++ b/apps/website/src/pages/docs/components/hover-card.mdx
@@ -1,4 +1,9 @@
 import { HoverCardExample } from '@/components/docs/hoverCard';
+import Head from 'next/head';
+
+<Head>
+  <title>Hover Card | EdgeUI</title>
+</Head>
 
 # Hover Card
 

--- a/apps/website/src/pages/docs/components/input.mdx
+++ b/apps/website/src/pages/docs/components/input.mdx
@@ -1,4 +1,9 @@
 import { InputExample } from '@/components/docs/inputs';
+import Head from 'next/head';
+
+<Head>
+  <title>Input | EdgeUI</title>
+</Head>
 
 # Input
 

--- a/apps/website/src/pages/docs/components/label.mdx
+++ b/apps/website/src/pages/docs/components/label.mdx
@@ -1,4 +1,9 @@
 import { CheckboxExample } from '@/components/docs/inputs';
+import Head from 'next/head';
+
+<Head>
+  <title>Label | EdgeUI</title>
+</Head>
 
 # Label
 

--- a/apps/website/src/pages/docs/components/layout.mdx
+++ b/apps/website/src/pages/docs/components/layout.mdx
@@ -1,3 +1,10 @@
+import Head from 'next/head';
+
+<Head>
+  <title>Layout | EdgeUI</title>
+</Head>
+
+
 # Layout
 
 This component provides a consistent and reusable structure for organizing the visual and functional elements of a web page or application.

--- a/apps/website/src/pages/docs/components/loader.mdx
+++ b/apps/website/src/pages/docs/components/loader.mdx
@@ -1,4 +1,9 @@
 import { LoaderExample } from '@/components/docs/loader';
+import Head from 'next/head';
+
+<Head>
+  <title>Loader | EdgeUI</title>
+</Head>
 
 # Loader
 

--- a/apps/website/src/pages/docs/components/menubar.mdx
+++ b/apps/website/src/pages/docs/components/menubar.mdx
@@ -1,4 +1,9 @@
 import { MenubarExample } from '@/components/docs/menubar';
+import Head from 'next/head';
+
+<Head>
+  <title>Menubar | EdgeUI</title>
+</Head>
 
 # Menubar
 

--- a/apps/website/src/pages/docs/components/navigation.mdx
+++ b/apps/website/src/pages/docs/components/navigation.mdx
@@ -1,4 +1,9 @@
 import { NavigationExample } from '@/components/docs/navigation';
+import Head from 'next/head';
+
+<Head>
+  <title>Navigation | EdgeUI</title>
+</Head>
 
 # Navigation
 

--- a/apps/website/src/pages/docs/components/popover.mdx
+++ b/apps/website/src/pages/docs/components/popover.mdx
@@ -1,4 +1,9 @@
 import { PopoverExample } from '@/components/docs/popover';
+import Head from 'next/head';
+
+<Head>
+  <title>Popover | EdgeUI</title>
+</Head>
 
 # Popover
 

--- a/apps/website/src/pages/docs/components/progress.mdx
+++ b/apps/website/src/pages/docs/components/progress.mdx
@@ -1,4 +1,9 @@
 import { ProgressExample } from '@/components/docs/progress';
+import Head from 'next/head';
+
+<Head>
+  <title>Progress | EdgeUI</title>
+</Head>
 
 # Progress
 

--- a/apps/website/src/pages/docs/components/scroll-area.mdx
+++ b/apps/website/src/pages/docs/components/scroll-area.mdx
@@ -1,4 +1,9 @@
 import { ScrollAreaExample } from '@/components/docs/scrollArea';
+import Head from 'next/head';
+
+<Head>
+  <title>Scroll Area | EdgeUI</title>
+</Head>
 
 # Scroll Area
 

--- a/apps/website/src/pages/docs/components/select.mdx
+++ b/apps/website/src/pages/docs/components/select.mdx
@@ -1,4 +1,9 @@
 import { SelectExample } from '@/components/docs/inputs';
+import Head from 'next/head';
+
+<Head>
+  <title>Select | EdgeUI</title>
+</Head>
 
 # Select
 

--- a/apps/website/src/pages/docs/components/separator.mdx
+++ b/apps/website/src/pages/docs/components/separator.mdx
@@ -1,4 +1,9 @@
 import { SeparatorExample } from '@/components/docs/separator';
+import Head from 'next/head';
+
+<Head>
+  <title>Separator | EdgeUI</title>
+</Head>
 
 # Separator
 

--- a/apps/website/src/pages/docs/components/sheet.mdx
+++ b/apps/website/src/pages/docs/components/sheet.mdx
@@ -1,4 +1,9 @@
 import { SheetExample } from '@/components/docs/sheet';
+import Head from 'next/head';
+
+<Head>
+  <title>Sheet | EdgeUI</title>
+</Head>
 
 # Sheet
 

--- a/apps/website/src/pages/docs/components/skeleton.mdx
+++ b/apps/website/src/pages/docs/components/skeleton.mdx
@@ -1,4 +1,9 @@
 import { SkeletonExample } from '@/components/docs/skeleton';
+import Head from 'next/head';
+
+<Head>
+  <title>Skeleton | EdgeUI</title>
+</Head>
 
 # Skeleton
 

--- a/apps/website/src/pages/docs/components/slider.mdx
+++ b/apps/website/src/pages/docs/components/slider.mdx
@@ -1,4 +1,9 @@
 import { SliderExample } from '@/components/docs/slider';
+import Head from 'next/head';
+
+<Head>
+  <title>Slider | EdgeUI</title>
+</Head>
 
 # Slider
 

--- a/apps/website/src/pages/docs/components/switch.mdx
+++ b/apps/website/src/pages/docs/components/switch.mdx
@@ -1,4 +1,9 @@
 import { SwitchExample } from '@/components/docs/inputs';
+import Head from 'next/head';
+
+<Head>
+  <title>Switch | EdgeUI</title>
+</Head>
 
 # Switch
 

--- a/apps/website/src/pages/docs/components/tab.mdx
+++ b/apps/website/src/pages/docs/components/tab.mdx
@@ -1,4 +1,9 @@
 import { TabExample } from '@/components/docs/tab';
+import Head from 'next/head';
+
+<Head>
+  <title>Tab | EdgeUI</title>
+</Head>
 
 # Tab
 

--- a/apps/website/src/pages/docs/components/table.mdx
+++ b/apps/website/src/pages/docs/components/table.mdx
@@ -1,4 +1,9 @@
 import { TableExample } from '@/components/docs/table';
+import Head from 'next/head';
+
+<Head>
+  <title>Table | EdgeUI</title>
+</Head>
 
 # Table
 

--- a/apps/website/src/pages/docs/components/textarea.mdx
+++ b/apps/website/src/pages/docs/components/textarea.mdx
@@ -1,4 +1,9 @@
 import { TextareaExample } from '@/components/docs/inputs';
+import Head from 'next/head';
+
+<Head>
+  <title>Textarea | EdgeUI</title>
+</Head>
 
 # Textarea
 

--- a/apps/website/src/pages/docs/components/toast.mdx
+++ b/apps/website/src/pages/docs/components/toast.mdx
@@ -1,4 +1,9 @@
 import { ToastExample } from '@/components/docs/toast';
+import Head from 'next/head';
+
+<Head>
+  <title>Toast | EdgeUI</title>
+</Head>
 
 # Toast
 

--- a/apps/website/src/pages/docs/components/tooltip.mdx
+++ b/apps/website/src/pages/docs/components/tooltip.mdx
@@ -1,4 +1,9 @@
 import { TooltipExample } from '@/components/docs/tooltip';
+import Head from 'next/head';
+
+<Head>
+  <title>Tooltip | EdgeUI</title>
+</Head>
 
 # Tooltip
 

--- a/apps/website/src/pages/docs/components/typography.mdx
+++ b/apps/website/src/pages/docs/components/typography.mdx
@@ -1,3 +1,10 @@
+import Head from 'next/head';
+
+<Head>
+  <title>Typography | EdgeUI</title>
+</Head>
+
+
 # Typography
 
 Provides typography utilities.

--- a/apps/website/src/pages/docs/hooks/use-boolean.mdx
+++ b/apps/website/src/pages/docs/hooks/use-boolean.mdx
@@ -1,3 +1,10 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useBoolean | EdgeUI</title>
+</Head>
+
+
 # useBoolean
 
 This hook can be used to manage boolean state. It is very similar to [useToggle](/docs/hooks/use-toggle) hook.

--- a/apps/website/src/pages/docs/hooks/use-breakpoint.mdx
+++ b/apps/website/src/pages/docs/hooks/use-breakpoint.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useBreakpoint | EdgeUI</title>
+</Head>
+
 # useBreakpoint
 
 This hook can be used to verify the breakpoint using media query.

--- a/apps/website/src/pages/docs/hooks/use-clipboard.mdx
+++ b/apps/website/src/pages/docs/hooks/use-clipboard.mdx
@@ -1,3 +1,10 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useClipboard | EdgeUI</title>
+</Head>
+
+
 # useClipboard
 
 This hook can be used to manage clipboard content.

--- a/apps/website/src/pages/docs/hooks/use-debounce.mdx
+++ b/apps/website/src/pages/docs/hooks/use-debounce.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useDebounce | EdgeUI</title>
+</Head>
+
 # useDebounce
 
 This hook can be used to content based on the provided delay.

--- a/apps/website/src/pages/docs/hooks/use-hover.mdx
+++ b/apps/website/src/pages/docs/hooks/use-hover.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useHover | EdgeUI</title>
+</Head>
+
 # useHover
 
 This hook can be used to manage hovered state.

--- a/apps/website/src/pages/docs/hooks/use-image-load.mdx
+++ b/apps/website/src/pages/docs/hooks/use-image-load.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useImageLoad | EdgeUI</title>
+</Head>
+
 # useImageLoad
 
 This hook can be used to manage image load/error event.

--- a/apps/website/src/pages/docs/hooks/use-intersection-observer.mdx
+++ b/apps/website/src/pages/docs/hooks/use-intersection-observer.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useIntersectionObserver | EdgeUI</title>
+</Head>
+
 # useIntersectionObserver
 
 This hook can be used to manage intersection observer.

--- a/apps/website/src/pages/docs/hooks/use-media-query.mdx
+++ b/apps/website/src/pages/docs/hooks/use-media-query.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useMediaQuery | EdgeUI</title>
+</Head>
+
 # useMediaQuery
 
 This hook can be used to handle media query.

--- a/apps/website/src/pages/docs/hooks/use-theme.mdx
+++ b/apps/website/src/pages/docs/hooks/use-theme.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useTheme | EdgeUI</title>
+</Head>
+
 # useTheme
 
 This hook can be used to manage EdgeUI theme.

--- a/apps/website/src/pages/docs/hooks/use-toast.mdx
+++ b/apps/website/src/pages/docs/hooks/use-toast.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useToast | EdgeUI</title>
+</Head>
+
 # useToast
 
 This hook can be used to manage toast alerts.

--- a/apps/website/src/pages/docs/hooks/use-toggle.mdx
+++ b/apps/website/src/pages/docs/hooks/use-toggle.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useToggle | EdgeUI</title>
+</Head>
+
 # useToggle
 
 This hook can be used to manage on/off state. It is very similar to [useBoolean](/docs/hooks/use-boolean) hook.

--- a/apps/website/src/pages/docs/hooks/use-xeffect.mdx
+++ b/apps/website/src/pages/docs/hooks/use-xeffect.mdx
@@ -1,3 +1,9 @@
+import Head from 'next/head';
+
+<Head>
+  <title>useXEffect | EdgeUI</title>
+</Head>
+
 # useXEffect
 
 The signature of this hook is similar to `useEffect` but uses `useLayoutEffect` on the browser and `useEffect` on the server.

--- a/apps/website/src/pages/docs/installation.mdx
+++ b/apps/website/src/pages/docs/installation.mdx
@@ -1,5 +1,10 @@
 import { Alert, AlertDescription, AlertTitle, Code } from '@edge-ui/react';
 import { AlertCircle } from 'lucide-react';
+import Head from 'next/head';
+
+<Head>
+  <title>Installation | EdgeUI</title>
+</Head>
 
 # Installation
 

--- a/apps/website/src/pages/docs/introduction.mdx
+++ b/apps/website/src/pages/docs/introduction.mdx
@@ -1,5 +1,10 @@
 import { Alert, AlertDescription, AlertTitle } from '@edge-ui/react';
 import { Copyright } from 'lucide-react';
+import Head from 'next/head';
+
+<Head>
+  <title>Introduction | EdgeUI</title>
+</Head>
 
 # Introduction
 

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import {
     Heading,
-    Layout,
     Card,
     CardHeader,
     CardTitle,

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -9,11 +9,17 @@ import {
     Flex
 } from '@edge-ui/react';
 import Link from 'next/link';
+import Head from 'next/head';
 import { ComponentIcon, PenToolIcon } from 'lucide-react';
 
 export default function Home() {
     return (
         <>
+            <Head>
+                <title>EdgeUI - A Minimal UI Components Library</title>
+                <meta name="description" content="A Minimal UI components library for building modern websites and applications using React." />
+            </Head>
+
             <div className="text-center space-y-8 max-w-[850px] mx-auto">
                 <Heading.H1 className="text-6xl md:text-7xl">EdgeUI</Heading.H1>
                 <Heading.H3 className="text-muted-foreground">


### PR DESCRIPTION
Used `next/head` to implement titles for all documentation pages (including .mdx files)